### PR TITLE
feat: Endpoint that fetch all registration attendeee for a particular…

### DIFF
--- a/backend/controllers/EventController.js
+++ b/backend/controllers/EventController.js
@@ -88,3 +88,31 @@ export const fetchSingleEventDetails = async (req, res) => {
     return failure(res, err.message, [], 500);
   }
 };
+
+export const fetchEventRegistrationAttendeesForOneEvent = async (req, res) => {
+  try {
+    const { event_id } = req.params;
+    const { page = 1, limit = 10 } = req.query;
+
+    const event = await Event.findByEventId(event_id);
+    
+    if (!event) {
+      return failure(res, "Event not found", [], 404);
+    }
+
+    const registrations = await Event.getRegisteredUsersWithPagination(
+      event_id,
+      page,
+      limit
+    );
+
+    return success(
+      res,
+      "Registered attendees fetched successfully",
+      registrations,
+      200
+    );
+  } catch (err) {
+    return failure(res, err.message, [], 500);
+  }
+};

--- a/backend/models/Event.js
+++ b/backend/models/Event.js
@@ -138,12 +138,12 @@ class Event {
       .where({ event_id, is_active: true })
       .count("id as count")
       .first();
-    
+
     const rsvps = await db("event_rsvps")
       .where({ event_id })
       .count("id as count")
       .first();
-    
+
     const attendance = await db("event_attendance")
       .where({ event_id })
       .count("id as count")
@@ -152,7 +152,33 @@ class Event {
     return {
       registrations: registrations.count,
       rsvps: rsvps.count,
-      attendance: attendance.count
+      attendance: attendance.count,
+    };
+  }
+
+  static async getRegisteredUsersWithPagination(
+    event_id,
+    page = 1,
+    per_page = 10
+  ) {
+    const offset = (page - 1) * per_page;
+
+    const registeredUsers = await db("event_registrations")
+      .where({ event_id, is_active: true })
+      .select("user_address")
+      .limit(per_page)
+      .offset(offset);
+
+    const total = await db("event_registrations")
+      .where({ event_id, is_active: true })
+      .count({ count: "*" })
+      .first();
+
+    return {
+      data: registeredUsers,
+      total: total.count,
+      current: page,
+      pages: Math.ceil(total.count / per_page),
     };
   }
 }

--- a/backend/routes/event.js
+++ b/backend/routes/event.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   add,
   all,
+  fetchEventRegistrationAttendeesForOneEvent,
   fetchSingleEventDetails,
   search,
   view,
@@ -19,5 +20,9 @@ router.get("/id/:event_id", viewByEventId);
 router.get("/owner/:event_owner", viewByEventOwner);
 router.get("/:id", view);
 router.get("/:event_id/details", fetchSingleEventDetails);
+router.get(
+  "/:event_id/registrations",
+  fetchEventRegistrationAttendeesForOneEvent
+);
 
 export default router;


### PR DESCRIPTION
feat: Endpoint that fetch all registration attendeee for a particular events - Backend #47
## Pull Request: Add Event Registrations Endpoint

### 📝 Description
This PR adds a new endpoint to fetch paginated event registrations by `event_id`. The implementation allows retrieving a list of registered users for a specific event with pagination support.

### 🚀 Features
- New endpoint `/:event_id/registrations`
- Pagination support for event registrations
- Validates event existence before fetching registrations
- Returns only active registrations
- Includes pagination metadata in response

### 🔧 Changes
- Added `fetchEventRegistrationAttendeesForOneEvent` method in Event Controller
- Added `getRegisteredUsersWithPagination` method in Event Model
- Implemented route for fetching event registrations
- Formatted `models/Event.js`, `controllers/EventController.js`, `routes/Event.js`.

### 💡 Implementation Details
- Default pagination: 10 items per page
- Supports custom page and limit via query parameters
- Returns user addresses of registered attendees
- Provides total count, current page, and total pages in response