### PR TITLE
Feat: Function to fetch all events created by an orgainzer

### DIFF
--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -356,15 +356,13 @@ pub mod ChainEvents {
             let event_count = self.event_counts.read();
 
             while count <= event_count {
-                if self.event_owners.read(count) == caller{
-                    
-                    caller_events.append(self.event_details.read(count)); 
+                if self.event_owners.read(count) == caller {
+                    caller_events.append(self.event_details.read(count));
                 }
-                count +=1;
-            
-        };
-        caller_events
-}
+                count += 1;
+            };
+            caller_events
+        }
     }
 
     #[generate_trait]
@@ -578,6 +576,4 @@ pub mod ChainEvents {
             self.attendee_event_registration_counts.read(event_id)
         }
     }
-
-    
 }

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -346,6 +346,25 @@ pub mod ChainEvents {
             self.ownable.assert_only_owner();
             self.upgradeable.upgrade(new_class_hash);
         }
+
+        /// @notice Get fetch all event created by the function caller to pay for an event
+        /// @return Array of events created by the caller
+        fn events_by_organizer(self: @ContractState) -> Array<EventDetails> {
+            let caller = get_caller_address();
+            let mut caller_events = ArrayTrait::new();
+            let mut count = 0;
+            let event_count = self.event_counts.read();
+
+            while count <= event_count {
+                if self.event_owners.read(count) == caller{
+                    
+                    caller_events.append(self.event_details.read(count)); 
+                }
+                count +=1;
+            
+        };
+        caller_events
+}
     }
 
     #[generate_trait]
@@ -560,19 +579,5 @@ pub mod ChainEvents {
         }
     }
 
-    /// @notice Get fetch all event created by the function caller to pay for an event
-        /// @return Array of events created by the caller
-        fn events_by_organizer(self: @ContractState) -> Array<u256> {
-            let caller = get_caller_address();
-            let mut caller_events = array![];
-
-            for i in 0..self.event_counts.read() {
-                let address = self.event_owners.read(i);
-                if address == caller {
-                    caller_events.append(i);
-                }
-            };
-            
-            caller_events
-        }
+    
 }

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -559,4 +559,20 @@ pub mod ChainEvents {
             self.attendee_event_registration_counts.read(event_id)
         }
     }
+
+    /// @notice Get fetch all event created by the function caller to pay for an event
+        /// @return Array of events created by the caller
+        fn events_by_organizer(self: @ContractState) -> Array<u256> {
+            let caller = get_caller_address();
+            let mut caller_events = array![];
+
+            for i in 0..self.event_counts.read() {
+                let address = self.event_owners.read(i);
+                if address == caller {
+                    caller_events.append(i);
+                }
+            };
+            
+            caller_events
+        }
 }

--- a/src/interfaces/IEvent.cairo
+++ b/src/interfaces/IEvent.cairo
@@ -27,7 +27,7 @@ pub trait IEvent<TContractState> {
     fn paid_event_ticket_counts(self: @TContractState, event_id: u256) -> u256;
     fn event_total_amount_paid(self: @TContractState, event_id: u256) -> u256;
     fn get_events(self: @TContractState) -> Array<EventDetails>;
-    fn events_by_organizer(self: @TContractState) -> Array<u256>;
+    fn events_by_organizer(self: @TContractState) -> Array<EventDetails>;
 
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
 }

--- a/src/interfaces/IEvent.cairo
+++ b/src/interfaces/IEvent.cairo
@@ -27,6 +27,7 @@ pub trait IEvent<TContractState> {
     fn paid_event_ticket_counts(self: @TContractState, event_id: u256) -> u256;
     fn event_total_amount_paid(self: @TContractState, event_id: u256) -> u256;
     fn get_events(self: @TContractState) -> Array<EventDetails>;
+    fn events_by_organizer(self: @TContractState) -> Array<u256>;
 
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -764,26 +764,22 @@ fn test_event_total_amount_paid() {
 
 #[test]
 fn test_events_by_organizer() {
-    let _strk_token = deploy_token_contract();
-    let event_contract_address = __setup__(_strk_token);
+    let strk_token = deploy_token_contract();
+    let event_contract_address = __setup__(strk_token);
     let event_dispatcher = IEventDispatcher { contract_address: event_contract_address };
 
+    let mut events: Array<EventDetails> = ArrayTrait::<EventDetails>::new();
+
+    let organizer: ContractAddress = USER_ONE.try_into().unwrap();
+    start_cheat_caller_address(event_contract_address, organizer);
+    let initial_event_id = event_dispatcher.add_event("Blockchain Conference", "Tech Park");
+   
     
-    start_cheat_caller_address(event_contract_address, USER_ONE.try_into().unwrap());
-    let event_id_1 = event_dispatcher.add_event("Event 1", "Location 1");
-    let _event_id_2 = event_dispatcher.add_event("Event 2", "Location 2");
-
-    let events = event_dispatcher.events_by_organizer();
-
-    assert_eq!(events.len(), 2, "Expected 2 events for the caller");
-
+    let organizer_events: Array<EventDetails> = event_dispatcher.events_by_organizer();
     
-    let mut found_event_id_1 = false;
-    for event in events {
-        if event == event_id_1 {
-            found_event_id_1 = true;
-            break;
-        }
-    };
-    assert(found_event_id_1, 'Event ID 1 missing');
+    let first_event: EventDetails = organizer_events.at(0).clone().try_into().unwrap();
+
+   
+    assert(first_event.organizer == organizer, 'Wrong organizer');
+   
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -773,13 +773,10 @@ fn test_events_by_organizer() {
     let organizer: ContractAddress = USER_ONE.try_into().unwrap();
     start_cheat_caller_address(event_contract_address, organizer);
     let initial_event_id = event_dispatcher.add_event("Blockchain Conference", "Tech Park");
-   
-    
+
     let organizer_events: Array<EventDetails> = event_dispatcher.events_by_organizer();
-    
+
     let first_event: EventDetails = organizer_events.at(0).clone().try_into().unwrap();
 
-   
     assert(first_event.organizer == organizer, 'Wrong organizer');
-   
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -761,3 +761,29 @@ fn test_event_total_amount_paid() {
     event_dispatcher.event_total_amount_paid(event_id);
     assert(event_id == 1, 'Invalid event');
 }
+
+#[test]
+fn test_events_by_organizer() {
+    let _strk_token = deploy_token_contract();
+    let event_contract_address = __setup__(_strk_token);
+    let event_dispatcher = IEventDispatcher { contract_address: event_contract_address };
+
+    
+    start_cheat_caller_address(event_contract_address, USER_ONE.try_into().unwrap());
+    let event_id_1 = event_dispatcher.add_event("Event 1", "Location 1");
+    let _event_id_2 = event_dispatcher.add_event("Event 2", "Location 2");
+
+    let events = event_dispatcher.events_by_organizer();
+
+    assert_eq!(events.len(), 2, "Expected 2 events for the caller");
+
+    
+    let mut found_event_id_1 = false;
+    for event in events {
+        if event == event_id_1 {
+            found_event_id_1 = true;
+            break;
+        }
+    };
+    assert(found_event_id_1, 'Event ID 1 missing');
+}


### PR DESCRIPTION
A function that allows fetching all events created by an organizer. Modifications were made in `chainevents.cairo` to implement the logic for retrieving events based on the organizer's ID. The new function provides a streamlined way to access events, improving the overall user experience and efficiency in event management. This feature aims to enhance the event management capabilities of the application, making it easier for organizers to view and manage their events.