### PR TITLE
Fix error in `attendee_event_details` function. 

### DIFF
--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -42,7 +42,7 @@ pub mod ChainEvents {
         event_owners: Map<u256, ContractAddress>, // map(event_id, eventOwnerAddress)
         event_counts: u256,
         event_details: Map<u256, EventDetails>, // map(event_id, EventDetailsParams)
-        event_registrations: Map<ContractAddress, u256>, // map<attendeeAddress, event_id>
+        event_registrations: Map<(ContractAddress, u256), bool>, // map<(attendeeAddress, event_id), bool> -> true means that the attende is registered to the event
         attendee_event_details: Map<
             (u256, ContractAddress), EventRegistration,
         >, // map <(event_id, attendeeAddress), EventRegistration>
@@ -447,7 +447,7 @@ pub mod ChainEvents {
 
             self.attendee_event_details.write((event_id, caller), _attendee_event_details);
 
-            self.event_registrations.write(caller, event_id);
+            self.event_registrations.write((caller, event_id), true);
 
             // update event attendees count.
             self.registered_attendees.write(event_id, self.registered_attendees.read(event_id) + 1);
@@ -482,7 +482,7 @@ pub mod ChainEvents {
                     },
                 );
 
-            self.event_registrations.write(caller, 0);
+            self.event_registrations.write((caller, event_id), false);
 
             self.registered_attendees.write(event_id, self.registered_attendees.read(event_id) - 1);
             let current_count = self.attendee_event_registration_counts.read(event_id);
@@ -551,9 +551,9 @@ pub mod ChainEvents {
         }
 
         fn _attendee_event_details(self: @ContractState, event_id: u256) -> EventRegistration {
-            let register_event_id = self.event_registrations.read(get_caller_address());
+            let register_event_id = self.event_registrations.read((get_caller_address(), event_id));
 
-            assert(event_id == register_event_id, 'different event_id');
+            assert(register_event_id, 'different event_id');
 
             let attendee_event_details = self
                 .attendee_event_details

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -42,7 +42,9 @@ pub mod ChainEvents {
         event_owners: Map<u256, ContractAddress>, // map(event_id, eventOwnerAddress)
         event_counts: u256,
         event_details: Map<u256, EventDetails>, // map(event_id, EventDetailsParams)
-        event_registrations: Map<(ContractAddress, u256), bool>, // map<(attendeeAddress, event_id), bool> -> true means that the attende is registered to the event
+        event_registrations: Map<
+            (ContractAddress, u256), bool
+        >, // map<(attendeeAddress, event_id), bool> -> true means that the attende is registered to the event
         attendee_event_details: Map<
             (u256, ContractAddress), EventRegistration,
         >, // map <(event_id, attendeeAddress), EventRegistration>

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -120,10 +120,10 @@ fn test_registration_to_multiple_events() {
 
     event_dispatcher.register_for_event(event_id_1);
     event_dispatcher.register_for_event(event_id_2);
-    
+
     let event_details_1 = event_dispatcher.event_details(event_id_1);
     let event_details_2 = event_dispatcher.event_details(event_id_2);
-    
+
     let attendee_registration_details_1 = event_dispatcher.attendee_event_details(event_id_1);
     let attendee_registration_details_2 = event_dispatcher.attendee_event_details(event_id_2);
 
@@ -146,10 +146,12 @@ fn test_registration_to_multiple_events() {
     assert(attendee_registration_details_1.nft_token_id == 0, 'E1: nft_token_id mismatch');
     assert(attendee_registration_details_2.nft_token_id == 0, 'E2: nft_token_id mismatch');
     assert(
-        attendee_registration_details_1.organizer == event_details_1.organizer, 'E1: organizer mismatch'
+        attendee_registration_details_1.organizer == event_details_1.organizer,
+        'E1: organizer mismatch'
     );
     assert(
-        attendee_registration_details_2.organizer == event_details_2.organizer, 'E2: organizer mismatch'
+        attendee_registration_details_2.organizer == event_details_2.organizer,
+        'E2: organizer mismatch'
     );
     stop_cheat_caller_address(event_contract_address);
 }


### PR DESCRIPTION
### Issue Solved: #110 

### Proposed solution: https://github.com/mubarak23/chainevents-contracts/issues/110#issuecomment-2616166540

### Changes Implemented:
- Change the storage's variable `event_registrations` from `Map<ContractAddress, u256>` to  `Map<(ContractAddress, u256), bool>` to allow the caller to register to multiple events without loose the previous one and also maintaining low gas fees and good performance. 
- Modify functions `_register_for_event` and `_unregister_from_event` to be adapted to the new `event_registrations` variable. 
- Create new test_case `test_registration_to_multiple_events` that evaluates that the same user can register to more than one event at once, without loosing the register to the previous ones. 
