### PR TITLE
Implement fetch all unpaid events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Welcome, contributing to `chainevents` is easy!
 1. Submit or comment your intent on an issue
 1. We will try to respond quickly
 1. Fork this repo (fork all branches)
-1. Submit your PR against `develop`
+1. Submit your PR against `main`
 1. Address PR Review
 
 ### Issue

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -776,28 +776,12 @@ pub mod ChainEvents {
             all_unpaid_events
         }
 
-        fn _fetch_user_paid_event(self: @ContractState, caller: ContractAddress) -> (u256, u256) git {
+        fn _fetch_user_paid_event(self: @ContractState, caller: ContractAddress) -> (u256, u256) {
             // read the paid event details.
             let (event_id, amount_paid) = self.paid_events.read(caller);
 
             // return event_id and amount paid.
             (event_id, amount_paid)
-        }
-        
-        fn _fetch_all_unpaid_events(self: @ContractState) -> Array<EventDetails> {
-            let mut all_unpaid_events = ArrayTrait::new();
-            let total_events_counts = self.event_counts.read();
-
-            let mut count: u256 = 1;
-
-            while count <= total_events_counts {
-                let current_event = self.event_details.read(count);
-                if current_event.event_type == EventType::Free {
-                    all_unpaid_events.append(current_event);
-                }
-                count += 1;
-            };
-            all_unpaid_events
         }
     }
 }

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -363,15 +363,11 @@ pub mod ChainEvents {
                     WithdrawalMade { event_id, event_organizer: event_owner, amount: event_amount }
                 );
         }
-
         fn fetch_user_paid_event(self: @ContractState) -> (u256, u256) {
             let caller = get_caller_address();
-            // read the paid event details.
-            let (event_id, amount_paid) = self.paid_events.read(caller);
-
-            // return event_id and amount paid.
-            (event_id, amount_paid)
+            self._fetch_user_paid_event(caller)
         }
+
         fn paid_event_ticket_counts(self: @ContractState, event_id: u256) -> u256 {
             self._paid_event_ticket_counts(event_id)
         }
@@ -778,6 +774,14 @@ pub mod ChainEvents {
                 count += 1;
             };
             all_unpaid_events
+        }
+
+        fn _fetch_user_paid_event(self: @ContractState, caller: ContractAddress) -> (u256, u256) git {
+            // read the paid event details.
+            let (event_id, amount_paid) = self.paid_events.read(caller);
+
+            // return event_id and amount paid.
+            (event_id, amount_paid)
         }
     }
 }

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -783,5 +783,21 @@ pub mod ChainEvents {
             // return event_id and amount paid.
             (event_id, amount_paid)
         }
+        
+        fn _fetch_all_unpaid_events(self: @ContractState) -> Array<EventDetails> {
+            let mut all_unpaid_events = ArrayTrait::new();
+            let total_events_counts = self.event_counts.read();
+
+            let mut count: u256 = 1;
+
+            while count <= total_events_counts {
+                let current_event = self.event_details.read(count);
+                if current_event.event_type == EventType::Free {
+                    all_unpaid_events.append(current_event);
+                }
+                count += 1;
+            };
+            all_unpaid_events
+        }
     }
 }

--- a/src/events/chainevents.cairo
+++ b/src/events/chainevents.cairo
@@ -3,7 +3,6 @@
 /// @notice A contract for creating and managing events with registration and attendance tracking
 /// @dev Implements Ownable and Upgradeable components from OpenZeppelin
 pub mod ChainEvents {
-    use openzeppelin_access::ownable::interface::IOwnable;
     use core::num::traits::zero::Zero;
     use chainevents_contracts::base::types::{EventDetails, EventRegistration, EventType};
     use chainevents_contracts::base::errors::Errors::{
@@ -421,6 +420,10 @@ pub mod ChainEvents {
         fn fetch_all_paid_events(self: @ContractState) -> Array<EventDetails> {
             self._fetch_all_paid_events()
         }
+
+        fn fetch_all_unpaid_events(self: @ContractState) -> Array<EventDetails> {
+            self._fetch_all_unpaid_events()
+        }
     }
 
     #[generate_trait]
@@ -757,8 +760,24 @@ pub mod ChainEvents {
 
         fn _paid_event_ticket_counts(self: @ContractState, event_id: u256) -> u256 {
             let caller = get_caller_address();
-            let (event_id, amount_paid) = self.paid_events.read(caller);
+            let (event_id, _) = self.paid_events.read(caller);
             self.paid_event_ticket_count.read(event_id)
+        }
+
+        fn _fetch_all_unpaid_events(self: @ContractState) -> Array<EventDetails> {
+            let mut all_unpaid_events = ArrayTrait::new();
+            let total_events_counts = self.event_counts.read();
+
+            let mut count: u256 = 1;
+
+            while count <= total_events_counts {
+                let current_event = self.event_details.read(count);
+                if current_event.event_type == EventType::Free {
+                    all_unpaid_events.append(current_event);
+                }
+                count += 1;
+            };
+            all_unpaid_events
         }
     }
 }

--- a/src/interfaces/IEvent.cairo
+++ b/src/interfaces/IEvent.cairo
@@ -37,6 +37,7 @@ pub trait IEvent<TContractState> {
     fn get_open_events(self: @TContractState) -> Array<EventDetails>;
     fn get_closed_events(self: @TContractState) -> Array<EventDetails>;
     fn fetch_all_paid_events(self: @TContractState) -> Array<EventDetails>;
+    fn fetch_all_unpaid_events(self: @TContractState) -> Array<EventDetails>;
 
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
 }


### PR DESCRIPTION
PR that closes issue #138 which fetch all free events to be render on the home page with open to filter Free events on the platform