### PR TITLE
Issue #154: Implement Get Ticket Owner and Is Ticket Used

### DIFF
--- a/src/events/ticketverification.cairo
+++ b/src/events/ticketverification.cairo
@@ -206,9 +206,9 @@ pub mod TicketVerification {
         }
 
         fn verify_ticket(ref self: ContractState, ticket_id: u256) -> bool {
-            // IMPORTANT NOTE 
+            // IMPORTANT NOTE
             // This function was modified to being able to test the function "is_ticket_used".
-            // Feel free to override with the real implementation when it's ready. 
+            // Feel free to override with the real implementation when it's ready.
             self.ticket_used.entry(ticket_id).write(true);
             false
         }
@@ -217,13 +217,13 @@ pub mod TicketVerification {
         /// Read Functions
         fn get_ticket_owner(self: @ContractState, ticket_id: u256) -> ContractAddress {
             let ticket_owner = self.ticket_owners.read(ticket_id);
-            assert(ticket_owner!=contract_address_const::<0x0>(), 'Ticket not exists');
+            assert(ticket_owner != contract_address_const::<0x0>(), 'Ticket not exists');
             ticket_owner
         }
-        
+
         fn is_ticket_used(self: @ContractState, ticket_id: u256) -> bool {
             let ticket_owner = self.ticket_owners.read(ticket_id);
-            assert(ticket_owner!=contract_address_const::<0x0>(), 'Ticket not exists');
+            assert(ticket_owner != contract_address_const::<0x0>(), 'Ticket not exists');
             let is_used = self.ticket_used.read(ticket_id);
             is_used
         }

--- a/src/events/ticketverification.cairo
+++ b/src/events/ticketverification.cairo
@@ -206,6 +206,10 @@ pub mod TicketVerification {
         }
 
         fn verify_ticket(ref self: ContractState, ticket_id: u256) -> bool {
+            // IMPORTANT NOTE 
+            // This function was modified to being able to test the function "is_ticket_used".
+            // Feel free to override with the real implementation when it's ready. 
+            self.ticket_used.entry(ticket_id).write(true);
             false
         }
         fn transfer_ticket(ref self: ContractState, ticket_id: u256, to: ContractAddress) {}
@@ -216,9 +220,12 @@ pub mod TicketVerification {
             assert(ticket_owner!=contract_address_const::<0x0>(), 'Ticket not exists');
             ticket_owner
         }
-
+        
         fn is_ticket_used(self: @ContractState, ticket_id: u256) -> bool {
-            true
+            let ticket_owner = self.ticket_owners.read(ticket_id);
+            assert(ticket_owner!=contract_address_const::<0x0>(), 'Ticket not exists');
+            let is_used = self.ticket_used.read(ticket_id);
+            is_used
         }
         // fn get_event_details(self: @ContractState, event_id: u256) -> EventDetails {}
     }

--- a/src/events/ticketverification.cairo
+++ b/src/events/ticketverification.cairo
@@ -211,7 +211,12 @@ pub mod TicketVerification {
         fn transfer_ticket(ref self: ContractState, ticket_id: u256, to: ContractAddress) {}
 
         /// Read Functions
-        // fn get_ticket_owner(self: @ContractState, ticket_id: u256) -> ContractAddress {}
+        fn get_ticket_owner(self: @ContractState, ticket_id: u256) -> ContractAddress {
+            let ticket_owner = self.ticket_owners.read(ticket_id);
+            assert(ticket_owner!=contract_address_const::<0x0>(), 'Ticket not exists');
+            ticket_owner
+        }
+
         fn is_ticket_used(self: @ContractState, ticket_id: u256) -> bool {
             true
         }

--- a/src/interfaces/ITicketVerification.cairo
+++ b/src/interfaces/ITicketVerification.cairo
@@ -17,7 +17,7 @@ pub trait ITicketVerification<TContractState> {
     fn transfer_ticket(ref self: TContractState, ticket_id: u256, to: ContractAddress);
 
     /// Read Functions
-    // fn get_ticket_owner(self: @TContractState, ticket_id: u256) -> ContractAddress;
+    fn get_ticket_owner(self: @TContractState, ticket_id: u256) -> ContractAddress;
     fn is_ticket_used(self: @TContractState, ticket_id: u256) -> bool;
     // fn get_event_details(self: @TContractState, event_id: u256) -> EventDetails;
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1606,7 +1606,7 @@ fn test_is_ticket_used_false() {
 
     // get data about ticket usage
     let is_ticket_used = ticket_verification_contract.is_ticket_used(ticket_id);
-    
+
     // assert ticket used
     assert!(!is_ticket_used, "Should not be used");
 }
@@ -1642,15 +1642,15 @@ fn test_is_ticket_used_true() {
     start_cheat_caller_address(ticket_verification_contract_address, buyer);
     let ticket_id = ticket_verification_contract.mint_ticket(event_id, buyer);
     stop_cheat_caller_address(ticket_verification_contract_address);
-    
-    // call "verify_ticket" to use the ticket 
+
+    // call "verify_ticket" to use the ticket
     start_cheat_caller_address(ticket_verification_contract_address, buyer);
     ticket_verification_contract.verify_ticket(event_id);
     stop_cheat_caller_address(ticket_verification_contract_address);
 
     // get data about ticket usage
     let is_ticket_used = ticket_verification_contract.is_ticket_used(ticket_id);
-    
+
     // assert ticket used
     assert!(is_ticket_used, "Should be already used");
 }
@@ -1687,7 +1687,7 @@ fn test_is_ticket_used_not_exist() {
     start_cheat_caller_address(ticket_verification_contract_address, buyer);
     let ticket_id = ticket_verification_contract.mint_ticket(event_id, buyer);
     stop_cheat_caller_address(ticket_verification_contract_address);
-    
+
     // try to call is_ticket_used with a non existant id
     let not_existant_ticket_id = ticket_id + 1;
     ticket_verification_contract.is_ticket_used(not_existant_ticket_id);


### PR DESCRIPTION
##
### Related issue: #154 
##
### Changes implemented following to proposal [of this message](https://github.com/mubarak23/chainevents-contracts/issues/154#issuecomment-2671635024):

- Implement get_ticket_owner function and it's tests -> `test_get_ticket_owner`, `test_get_ticket_owner_ticket_not_exist`.
- Implement is_ticket_used function and it's tests -> `test_is_ticket_used_false`, `test_is_ticket_used_true`, `test_is_ticket_used_not_exist`.
- IMPORTANT: I wrote some partial logic of the function `verify_ticket` to being able to test correctly `is_ticket_used`, because I needed to test the case when it returns true. This logic I wrote for `verify_ticket` could/should be overitted with no problem, so if it gives merge conflicts with this issue -> #153 feel totally free to just replace it with the correspondant code.  