### PR TITLE
Fix mint_ticket payment to send funds to event owner

### DIFF
--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1429,8 +1429,9 @@ fn test_mint_ticket() {
     // Verify ticket minting
     assert(ticket_id == 0, 'Wrong ticket ID');
     assert(token.balance_of(buyer) == 0, 'Wrong buyer balance');
+    let event_owner: ContractAddress = OWNER();
     assert(
-        token.balance_of(ticket_verification_contract_address) == amount, 'Wrong contract balance'
+        token.balance_of(event_owner) == amount, 'Wrong contract balance'
     );
 
     // Verify event emission

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1430,9 +1430,7 @@ fn test_mint_ticket() {
     assert(ticket_id == 0, 'Wrong ticket ID');
     assert(token.balance_of(buyer) == 0, 'Wrong buyer balance');
     let event_owner: ContractAddress = OWNER();
-    assert(
-        token.balance_of(event_owner) == amount, 'Wrong contract balance'
-    );
+    assert(token.balance_of(event_owner) == amount, 'Wrong contract balance');
 
     // Verify event emission
     let expected_event = TicketVerification::Event::TicketMinted(


### PR DESCRIPTION
> This PR refactors the mint_ticket function by:

Moving core logic to a private _mint_ticket function within InternalImpl.
Fixing a bug where ticket payments were incorrectly sent back to the minter instead of the event owner.
Fetching the event details using event_id and correctly transferring funds to the owner.
Changes Made
Extracted mint_ticket logic into _mint_ticket inside InternalImpl.
Updated payment logic:
Retrieves the event organizer from EventDetails.
Transfers funds to the event owner instead of the buyer.