### PR TITLE
Refactor create_ticket_event Function

### DIFF
--- a/src/events/ticketverification.cairo
+++ b/src/events/ticketverification.cairo
@@ -145,32 +145,9 @@ pub mod TicketVerification {
             // Only owner can create events
             self.ownable.assert_only_owner();
 
-            // Get and increment next event ID
-            let event_id = self.next_event_id.read();
-            self.next_event_id.write(event_id + 1);
+            // Create event using internal implementation
+            self._create_ticket_event(timestamp, venue, transferable, amount, ticket_num)
 
-            // Create new event
-            let event = TicketEvent {
-                timestamp: timestamp,
-                venue: venue,
-                transferable: transferable,
-                active: true,
-                amount: amount,
-                ticket_num: ticket_num,
-            };
-
-            // Store event
-            self.ticket_events_details.write(event_id, event);
-
-            // Emit event
-            self
-                .emit(
-                    TicketEventCreated {
-                        event_id: event_id, timestamp: timestamp, venue: venue, amount: amount,
-                    }
-                );
-
-            event_id
         }
 
         /// @notice Mints a new ticket for a specific event
@@ -289,6 +266,49 @@ pub mod TicketVerification {
         fn _upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             self.ownable.assert_only_owner();
             self.upgradeable.upgrade(new_class_hash);
+        }
+
+        /// @notice Internal implementation for creating a new ticket event
+        /// @param timestamp The scheduled time of the event
+        /// @param venue The location where the event will be held
+        /// @param transferable Whether tickets can be transferred between addresses
+        /// @param amount The cost per ticket in payment token
+        /// @param ticket_num The total number of tickets available
+        /// @return event_id The ID of the newly created ticket event
+        fn _create_ticket_event(
+            ref self: ContractState,
+            timestamp: u64,
+            venue: felt252,
+            transferable: bool,
+            amount: u256,
+            ticket_num: u256,
+        ) -> u256 {
+            // Get and increment next event ID
+            let event_id = self.next_event_id.read();
+            self.next_event_id.write(event_id + 1);
+
+            // Create new event
+            let event = TicketEvent {
+                timestamp: timestamp,
+                venue: venue,
+                transferable: transferable,
+                active: true,
+                amount: amount,
+                ticket_num: ticket_num,
+            };
+
+            // Store event
+            self.ticket_events_details.write(event_id, event);
+
+            // Emit event
+            self
+                .emit(
+                    TicketEventCreated {
+                        event_id: event_id, timestamp: timestamp, venue: venue, amount: amount,
+                    }
+                );
+
+            event_id
         }
     }
 }

--- a/src/events/ticketverification.cairo
+++ b/src/events/ticketverification.cairo
@@ -147,7 +147,6 @@ pub mod TicketVerification {
 
             // Create event using internal implementation
             self._create_ticket_event(timestamp, venue, transferable, amount, ticket_num)
-
         }
 
         /// @notice Mints a new ticket for a specific event
@@ -271,6 +270,49 @@ pub mod TicketVerification {
             self.emit(TicketMinted { ticket_id: ticket_id, event_id: event_id, owner: to });
 
             ticket_id
+        }
+
+        /// @notice Internal implementation for creating a new ticket event
+        /// @param timestamp The scheduled time of the event
+        /// @param venue The location where the event will be held
+        /// @param transferable Whether tickets can be transferred between addresses
+        /// @param amount The cost per ticket in payment token
+        /// @param ticket_num The total number of tickets available
+        /// @return event_id The ID of the newly created ticket event
+        fn _create_ticket_event(
+            ref self: ContractState,
+            timestamp: u64,
+            venue: felt252,
+            transferable: bool,
+            amount: u256,
+            ticket_num: u256,
+        ) -> u256 {
+            // Get and increment next event ID
+            let event_id = self.next_event_id.read();
+            self.next_event_id.write(event_id + 1);
+
+            // Create new event
+            let event = TicketEvent {
+                timestamp: timestamp,
+                venue: venue,
+                transferable: transferable,
+                active: true,
+                amount: amount,
+                ticket_num: ticket_num,
+            };
+
+            // Store event
+            self.ticket_events_details.write(event_id, event);
+
+            // Emit event
+            self
+                .emit(
+                    TicketEventCreated {
+                        event_id: event_id, timestamp: timestamp, venue: venue, amount: amount,
+                    }
+                );
+
+            event_id
         }
     }
 }


### PR DESCRIPTION
# Refactor create_ticket_event Function

## Overview
This PR refactors the `create_ticket_event` function in the TicketVerification contract to improve code organization and maintainability.

## Changes
- Moved the implementation logic to an internal `_create_ticket_event` function
- Maintained owner-only access control for event creation
- Preserved all existing functionality while improving code structure

## Implementation Details
The refactored code:
- Keeps the public interface unchanged
- Enforces owner-only access via `assert_only_owner`
- Delegates actual event creation to internal implementation

## Testing
The existing functionality remains unchanged, but please test:
- Event creation as owner
- Access control restrictions
- Event creation parameters and storage

## Related Issue
Closes #161