### PR TITLE
feat: implement getters for group savings 

### DIFF
--- a/src/group/groupsavings.cairo
+++ b/src/group/groupsavings.cairo
@@ -37,25 +37,51 @@ mod GroupSaving {
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
-        // Group Management
+        // Tracks the total number of groups created (incremented in create_group).
         group_counts: u256,
+        // Maps group_id (felt252) to Group struct (creator, max_members, contribution_amount,
+        // duration_in_days).
+        // Used by view_group to retrieve group details.
         groups: Map<felt252, Group>,
-        // Member Contributions
+        // Maps (member_address, group_id) to the member's contribution amount (u128).
+        // Tracks contributions for each member in a group.
         member_contribution: Map<(ContractAddress, felt252), u128>,
+        // Maps (member_address, group_id) to the last round the member contributed to (u32).
+        // Used to track contribution history.
         member_last_contributed_round: Map<(ContractAddress, felt252), u32>,
+        // Maps (member_address, group_id) to a boolean indicating if the member has collected their
+        // payout.
+        // Tracks payout status for each member in a group.
         member_payout_status: Map<(ContractAddress, felt252), bool>,
-        // Contribution Cycle State
+        // Maps group_id to the current contribution round (u32).
+        // Used by get_current_round; defaults to 0 for non-started groups.
         group_current_round: Map<felt252, u32>,
+        // Maps group_id to a boolean indicating if the group has reached max_members.
+        // Used by is_group_full and updated in join_group.
         group_is_full: Map<felt252, bool>,
+        // Maps group_id to a boolean indicating if the group's contribution cycle is active.
+        // Tracks whether the group is currently running.
         group_is_active: Map<felt252, bool>,
+        // Maps group_id to a boolean indicating if the group has completed all rounds.
+        // Tracks group completion status.
         group_is_completed: Map<felt252, bool>,
+        // Maps group_id to the next index (u32) in the payout order.
+        // Tracks the current position in the payout sequence.
         group_next_payout_index: Map<felt252, u32>,
-        // Group Membership
-        group_members_list: Map<(felt252, u32), ContractAddress>, // Replaced group_members
-        // Track existing group IDs
+        // Maps (group_id, index) to a member’s ContractAddress.
+        // Stores the ordered list of group members, used by get_group_members to reconstruct the
+        // member list.
+        group_members_list: Map<(felt252, u32), ContractAddress>,
+        // Maps group_id to a boolean indicating if the group exists.
+        // Used by all getters and other functions to validate group_id.
         group_ids: Map<felt252, bool>,
+        // Maps (group_id, index) to a ContractAddress in the payout order.
+        // Stores the payout sequence set in create_group.
         group_payout_orders: Map<(felt252, u32), ContractAddress>,
+        // Maps group_id to the number of members (u32) in the group.
+        // Used by get_group_members and join_group to manage the member list.
         group_member_counts: Map<felt252, u32>,
+        // Maps a user’s ContractAddress to a group_id they created.
         user_groups: Map<ContractAddress, felt252>,
     }
 

--- a/src/interfaces/IGroupSaving.cairo
+++ b/src/interfaces/IGroupSaving.cairo
@@ -28,4 +28,9 @@ pub trait IGroupSaving<TContractState> {
     fn total_fees_collected(self: @TContractState) -> u256;
 
     fn upgrade_contract(ref self: TContractState, new_class_hash: ClassHash);
+
+    // Getterfunctions
+    fn get_current_round(self: @TContractState, group_id: felt252) -> u32;
+    fn is_group_full(self: @TContractState, group_id: felt252) -> bool;
+    fn get_group_members(self: @TContractState, group_id: felt252) -> Array<ContractAddress>;
 }

--- a/tests/test_group_savings_contract.cairo
+++ b/tests/test_group_savings_contract.cairo
@@ -133,3 +133,166 @@ fn test_failed_create_group_with_duplicate_id() {
     contract.create_group('1', creator, 5, 10000, 30, members);
     contract.create_group('1', creator, 2, 5000, 5, members1);
 }
+
+
+// Tests for getter functions
+#[test]
+fn test_get_current_round_active_group() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Simulate starting cycle (set round to 1)
+    store(
+        contract.contract_address,
+        selector!("group_current_round"),
+        array![1].span(),
+        array![group_id].span(),
+    );
+
+    // Test
+    let round = contract.get_current_round(group_id);
+    assert(round == 1, 'Current round should be 1');
+}
+
+#[test]
+fn test_get_current_round_not_started() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group (round defaults to 0)
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Test
+    let round = contract.get_current_round(group_id);
+    assert(round == 0, 'Current round should be 0');
+}
+
+#[test]
+#[should_panic(expected: ('Group Not Found',))]
+fn test_get_current_round_non_existent_group() {
+    let contract = contract();
+    let group_id = 'non_existent';
+
+    // Test - should panic
+    contract.get_current_round(group_id);
+}
+
+#[test]
+fn test_is_group_full_not_full() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Add 2 members (not full)
+    contract.join_group(group_id, member1);
+    contract.join_group(group_id, member2);
+
+    // Test
+    let is_full = contract.is_group_full(group_id);
+    assert(!is_full, 'Group should not be full');
+}
+
+#[test]
+fn test_is_group_full_full() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Add 3 members (full)
+    contract.join_group(group_id, member1);
+    contract.join_group(group_id, member2);
+    contract.join_group(group_id, member3);
+
+    // Test
+    let is_full = contract.is_group_full(group_id);
+    assert(is_full, 'Group should be full');
+}
+
+#[test]
+#[should_panic(expected: ('Group Not Found',))]
+fn test_is_group_full_non_existent_group() {
+    let contract = contract();
+    let group_id = 'non_existent';
+
+    // Test - should panic
+    contract.is_group_full(group_id);
+}
+
+#[test]
+fn test_get_group_members_with_members() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Add members
+    contract.join_group(group_id, member1);
+    contract.join_group(group_id, member2);
+
+    // Test
+    let returned_members = contract.get_group_members(group_id);
+    assert(returned_members.len() == 2, 'Should return 2 members');
+    assert(*returned_members.at(0) == member1, 'Member 1 mismatch');
+    assert(*returned_members.at(1) == member2, 'Member 2 mismatch');
+}
+
+#[test]
+fn test_get_group_members_empty_group() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group (no members yet)
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Test
+    let members = contract.get_group_members(group_id);
+    assert(members.len() == 0, 'Should return empty array');
+}
+
+#[test]
+#[should_panic(expected: ('Group Not Found',))]
+fn test_get_group_members_non_existent_group() {
+    let contract = contract();
+    let group_id = 'non_existent';
+
+    // Test - should panic
+    contract.get_group_members(group_id);
+}
+
+#[test]
+#[should_panic(expected: ('Member Already In Group',))]
+fn test_get_group_members_duplicate_member() {
+    let contract = contract();
+    let group_id = 'test_group';
+    let max_members = 3;
+    let payout_order = array![member1, member2, member3];
+
+    // Create group
+    contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
+
+    // Add member1
+    contract.join_group(group_id, member1);
+
+    // Try to add member1 again (should panic)
+    contract.join_group(group_id, member1);
+}

--- a/tests/test_group_savings_contract.cairo
+++ b/tests/test_group_savings_contract.cairo
@@ -7,7 +7,7 @@ use core::felt252;
 use core::traits::Into;
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
-    stop_cheat_caller_address,
+    stop_cheat_caller_address, store,
 };
 use starknet::{
     ClassHash, ContractAddress, get_block_timestamp, get_caller_address, get_contract_address,
@@ -146,13 +146,13 @@ fn test_get_current_round_active_group() {
     // Create group
     contract.create_group(group_id, creator, max_members, 100, 30, payout_order);
 
-    // Simulate starting cycle (set round to 1)
-    store(
-        contract.contract_address,
-        selector!("group_current_round"),
-        array![1].span(),
-        array![group_id].span(),
-    );
+    // Add all members to make the group full
+    contract.join_group(group_id, member1);
+    contract.join_group(group_id, member2);
+    contract.join_group(group_id, member3);
+
+    // Start the cycle
+    contract.start_cycle(group_id);
 
     // Test
     let round = contract.get_current_round(group_id);


### PR DESCRIPTION
This PR closes #180. It introduces getter functions (get_current_round, is_group_full, get_group_members) to the GroupSaving contract to expose key group states for transparency and external interface access (e.g., frontend UIs, indexers). 

It resolves a storage issue with group_members by replacing Array with an index-based Map, optimizes loop conditions for gas efficiency.

